### PR TITLE
Added support for unity_layer attribute

### DIFF
--- a/Assets/Houdini/Editor/HoudiniWindowSettings.cs
+++ b/Assets/Houdini/Editor/HoudiniWindowSettings.cs
@@ -879,6 +879,17 @@ public class HoudiniWindowSettings : EditorWindow
 				HoudiniHost.prUnityTagAttribName = value;
 		}
 
+        // Unity Layer Attrib Name
+        {
+            string value = HoudiniHost.prUnityLayerAttribName;
+            bool changed = HoudiniGUI.stringField(
+                "unity_layer_attrib_name", "Unity Layer Attrib.",
+                ref value, myUndoInfo,
+                ref myUndoInfo.unityLayerAttribName);
+            if (changed)
+                HoudiniHost.prUnityLayerAttribName = value;
+        }
+        
 		GUI.enabled = gui_enabled;
 	}
 

--- a/Assets/Houdini/Scripts/HoudiniHost.cs
+++ b/Assets/Houdini/Scripts/HoudiniHost.cs
@@ -150,6 +150,7 @@ public static partial class HoudiniHost
 	public const bool myDefaultSplitPointsByVertexAttributes			= true;
 
 	private const string myDefaultUnityTagAttribName					= "unity_tag";
+    private const string myDefaultUnityLayerAttribName					= "unity_layer";
 
 	private const float myDefaultPaintBrushRate							= 0.2f; // Should be between zero and one.
 	private const KeyCode myDefaultPaintingModeHotKey					= KeyCode.LeftShift;
@@ -234,6 +235,7 @@ public static partial class HoudiniHost
 		setBool(	"HAPI_SplitPointsByVertexAttributes", myDefaultSplitPointsByVertexAttributes, true );
 
 		setString(	"HAPI_UnityTagAttribName", myDefaultUnityTagAttribName, true );
+        setString(	"HAPI_UnityLayerAttribName", myDefaultUnityLayerAttribName, true );
 		
 		setFloat(	"HAPI_PaintBrushRate", myDefaultPaintBrushRate, true );
 		setKeyCode( "HAPI_PaintingHotKey", myDefaultPaintingModeHotKey, true );
@@ -391,6 +393,9 @@ public static partial class HoudiniHost
 	public static string prUnityTagAttribName {
 											get { return getString( "HAPI_UnityTagAttribName" ); }
 											set { setString( "HAPI_UnityTagAttribName", value ); } } 
+    public static string prUnityLayerAttribName {
+                                            get { return getString("HAPI_UnityLayerAttribName"); }
+                                            set { setString("HAPI_UnityLayerAttribName", value); } }
 
 	public static float prPaintBrushRate {
 											get { return getFloat( "HAPI_PaintBrushRate" ); }
@@ -582,6 +587,9 @@ public static partial class HoudiniHost
 	public static bool isUnityTagAttribNameDefault()
 											{ return	prUnityTagAttribName ==
 														myDefaultUnityTagAttribName; }
+    public static bool isUnityLayerAttribNameDefault()
+                                            { return    prUnityLayerAttribName ==
+                                                        myDefaultUnityLayerAttribName; }
 
 	public static bool isPaintBrushRateDefault()
 											{ return	prPaintBrushRate ==
@@ -687,6 +695,7 @@ public static partial class HoudiniHost
 		prSplitPointsByVertexAttributes 		= myDefaultSplitPointsByVertexAttributes;
 
 		prUnityTagAttribName					= myDefaultUnityTagAttribName;
+        prUnityLayerAttribName					= myDefaultUnityLayerAttribName;
 
 		prPaintBrushRate						= myDefaultPaintBrushRate;
 		prPaintingModeHotKey					= myDefaultPaintingModeHotKey;

--- a/Assets/Houdini/Scripts/HoudiniHostUndoInfo.cs
+++ b/Assets/Houdini/Scripts/HoudiniHostUndoInfo.cs
@@ -63,6 +63,7 @@ public class HoudiniHostUndoInfo : ScriptableObject
 	
 	// Geometry Settings
 	public string unityTagAttribName;
+    public string unityLayerAttribName;
 	public float paintBrushRate;
 	public KeyCode paintingModeHotKey;
 	public Color paintingModeColour;

--- a/Assets/Houdini/Scripts/HoudiniPartControl.cs
+++ b/Assets/Houdini/Scripts/HoudiniPartControl.cs
@@ -471,6 +471,9 @@ public class HoudiniPartControl : HoudiniGeoControl
 
 		// Assign unity tag.
 		assignUnityTag();
+        
+        // Assign unity layer.
+        assignUnityLayer();
 	}
 
 	public void createBoxCollider( HAPI_PartInfo part_info )
@@ -609,6 +612,32 @@ public class HoudiniPartControl : HoudiniGeoControl
 			}
 		}
 	}
+
+    private void assignUnityLayer()
+    {
+        HAPI_AttributeInfo layer_attr_info = new HAPI_AttributeInfo(HoudiniHost.prUnityLayerAttribName);
+        int[] layer_attr = new int[0];
+        HoudiniAssetUtility.getAttribute(
+            prGeoId, prPartId, HoudiniHost.prUnityLayerAttribName,
+            ref layer_attr_info, ref layer_attr, HoudiniHost.getAttributeStringData);
+
+        if (layer_attr_info.exists)
+        {
+            string layer = HoudiniHost.getString(layer_attr[0]);
+            if (layer != string.Empty)
+            {
+                try
+                {
+                    Debug.Log(layer);
+                    gameObject.layer = LayerMask.NameToLayer(layer);
+                }
+                catch
+                {
+                    Debug.LogWarning("Unity Layer " + layer + " is not defined!");
+                }
+            }
+        }
+    }
 
 	/////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// Serialized Private Data


### PR DESCRIPTION
By default houdini editor allows for settings unity tags via the
unity_tag attribute, there does not seem to be support for layers
though.
This adds that support.
Use a unity_layer attribute to set the layer you want your geo to have
assigned in unity.